### PR TITLE
Add Next v14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,11 @@ jobs:
           node-version: 20
       - run: npm install
       - run: npm run check-format
-  unittests:
-    name: Check Tests
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
     env:
       LOGTAIL_SOURCE_TOKEN: https://example.co/api/test
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - run: npm install
-      - run: npm test
-  build:
-    name: Build
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         node:
@@ -52,11 +42,12 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm install
       - run: npm run build
+      - run: npm test
   publish:
     name: Publish
     needs: 
       - check-format
-      - build
+      - build-and-test
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,15 @@ jobs:
           - 18.x
           - 19.x
           - 20.x
+        install-cmd:
+          - npm install
+          - npm update
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: ${{ matrix.install-cmd }}
       - run: npm run build
       - run: npm test
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
       - run: npm install
       - run: npm run check-format
   unittests:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
       - run: npm install
       - run: npm test
   build:
@@ -42,6 +42,9 @@ jobs:
           - 15.x
           - 16.x
           - 17.x
+          - 18.x
+          - 19.x
+          - 20.x
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "node": ">=15"
       },
       "peerDependencies": {
-        "next": "^12.1.4 || ^13"
+        "next": "^12.1.4 || ^13 || ^14"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/logtail/logtail-nextjs#readme",
   "peerDependencies": {
-    "next": "^12.1.4 || ^13"
+    "next": "^12.1.4 || ^13 || ^14"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",


### PR DESCRIPTION
Resolves #10 and improves CI a bit. The library seem to work as intended in Next.js v14 without any changes.

After merge:
- [ ] Bump version and release as `v0.1.1`