### PR TITLE
L-1016 Do not warn about missing environment variables in development

### DIFF
--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -20,6 +20,25 @@ declare global {
   var EdgeRuntime: string;
 }
 
+function warnAboutMissingEnvironmentVariables() {
+  let checkEnabled = process.env.NODE_ENV !== 'development';
+  if (process.env.LOGTAIL_CHECK_ENV_VARS?.toLowerCase() === 'true' || process.env.LOGTAIL_CHECK_ENV_VARS === '1') {
+    checkEnabled = true;
+  }
+  if (process.env.LOGTAIL_CHECK_ENV_VARS?.toLowerCase() === 'false' || process.env.LOGTAIL_CHECK_ENV_VARS === '0') {
+    checkEnabled = false;
+  }
+
+  if (checkEnabled) {
+    const log = new Logger();
+    log.warn(
+        'logtail: Envvars not detected. If this is production please see https://github.com/logtail/logtail-nextjs for help'
+    );
+    log.warn('logtail: Sending Web Vitals to /dev/null');
+    log.warn('logtail: Sending logs to console');
+  }
+}
+
 export function withLogtailNextConfig(nextConfig: NextConfig): NextConfig {
   return {
     ...nextConfig,
@@ -28,12 +47,8 @@ export function withLogtailNextConfig(nextConfig: NextConfig): NextConfig {
 
       const proxyEndpoint = config.getProxyEndpoint();
       if (!proxyEndpoint) {
-        const log = new Logger();
-        log.warn(
-          'logtail: Envvars not detected. If this is production please see https://github.com/logtail/logtail-nextjs for help'
-        );
-        log.warn('logtail: Sending Web Vitals to /dev/null');
-        log.warn('logtail: Sending logs to console');
+        warnAboutMissingEnvironmentVariables();
+
         return rewrites || []; // nothing to do
       }
 

--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -32,7 +32,7 @@ function warnAboutMissingEnvironmentVariables() {
   if (checkEnabled) {
     const log = new Logger();
     log.warn(
-        'logtail: Envvars not detected. If this is production please see https://github.com/logtail/logtail-nextjs for help'
+      'logtail: Envvars not detected. If this is production please see https://github.com/logtail/logtail-nextjs for help'
     );
     log.warn('logtail: Sending Web Vitals to /dev/null');
     log.warn('logtail: Sending logs to console');


### PR DESCRIPTION
Resolves #6 

The warning about missing ENV vars will be suppressed in `development` environment.

```
warn - logtail: Envvars not detected. If this is production please see https://github.com/logtailhq/next-logtail for help
warn - logtail: Sending Web Vitals to /dev/null
warn - logtail: Sending logs to console
```

---

For more granular control, you can enable or disable the check manually:

```bash
# to force the check even in development ENV, use either:
export LOGTAIL_CHECK_ENV_VARS=true
export LOGTAIL_CHECK_ENV_VARS=1

# to suppress the check even in other ENVs, use either:
export LOGTAIL_CHECK_ENV_VARS=false
export LOGTAIL_CHECK_ENV_VARS=0
```