### PR TITLE
L-1016 By default, don't check ENV vars in Vercel preview/development env

### DIFF
--- a/examples/logger/package-lock.json
+++ b/examples/logger/package-lock.json
@@ -1213,9 +1213,10 @@
             }
         },
         "../../node_modules/@types/node": {
-            "version": "17.0.29",
-            "dev": true,
-            "license": "MIT"
+            "version": "17.0.45",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+            "dev": true
         },
         "../../node_modules/@types/parse5": {
             "version": "6.0.3",
@@ -4617,9 +4618,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.9.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-            "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+            "version": "20.9.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
+            "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -4631,9 +4632,10 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "18.0.25",
+            "version": "18.2.38",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
+            "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -4641,9 +4643,10 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.0.9",
+            "version": "18.2.17",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
+            "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/react": "*"
             }
@@ -4654,24 +4657,26 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.10.1",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.12.0.tgz",
+            "integrity": "sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.10.1",
-                "@typescript-eslint/types": "5.10.1",
-                "@typescript-eslint/typescript-estree": "5.10.1",
-                "debug": "^4.3.2"
+                "@typescript-eslint/scope-manager": "6.12.0",
+                "@typescript-eslint/types": "6.12.0",
+                "@typescript-eslint/typescript-estree": "6.12.0",
+                "@typescript-eslint/visitor-keys": "6.12.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -4680,15 +4685,16 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.10.1",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.12.0.tgz",
+            "integrity": "sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "5.10.1",
-                "@typescript-eslint/visitor-keys": "5.10.1"
+                "@typescript-eslint/types": "6.12.0",
+                "@typescript-eslint/visitor-keys": "6.12.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4696,11 +4702,12 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.10.1",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.12.0.tgz",
+            "integrity": "sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4708,20 +4715,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.10.1",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.12.0.tgz",
+            "integrity": "sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "5.10.1",
-                "@typescript-eslint/visitor-keys": "5.10.1",
-                "debug": "^4.3.2",
-                "globby": "^11.0.4",
+                "@typescript-eslint/types": "6.12.0",
+                "@typescript-eslint/visitor-keys": "6.12.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4734,15 +4742,16 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.10.1",
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.12.0.tgz",
+            "integrity": "sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "5.10.1",
-                "eslint-visitor-keys": "^3.0.0"
+                "@typescript-eslint/types": "6.12.0",
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4853,8 +4862,9 @@
         },
         "node_modules/array-union": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -5198,8 +5208,9 @@
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -5720,11 +5731,15 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/espree": {
@@ -6034,8 +6049,9 @@
         },
         "node_modules/globby": {
             "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -6632,8 +6648,9 @@
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -6930,8 +6947,9 @@
         },
         "node_modules/path-type": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -7226,8 +7244,9 @@
         },
         "node_modules/semver": {
             "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -7302,8 +7321,9 @@
         },
         "node_modules/slash": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -7497,6 +7517,18 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/ts-api-utils": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.13.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7513,25 +7545,6 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -7784,8 +7797,9 @@
         },
         "node_modules/yallist": {
             "version": "4.0.0",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         }
     }
 }

--- a/examples/logger/pages/_app.tsx
+++ b/examples/logger/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { log } from '@logtail/next'
 import { AppProps } from "next/app";
+import Link from "next/link";
 
 export { reportWebVitals } from '@logtail/next'
 
@@ -10,8 +11,8 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Component {...pageProps} />
       <hr />
       <ul>
-          <li><a href="/">Homepage</a></li>
-          <li><a href="/serverSideProps">Server side props demo</a></li>
+          <li><Link href="/">Homepage</Link></li>
+          <li><Link href="/serverSideProps">Server side props demo</Link></li>
       </ul>
   </>
 }

--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -23,7 +23,8 @@ declare global {
 function warnAboutMissingEnvironmentVariables() {
   const nodeEnvironment = process.env.NODE_ENV;
   const vercelEnvironment = process.env.VERCEL_ENV;
-  let checkEnabled = nodeEnvironment !== 'development' && vercelEnvironment !== 'preview' && vercelEnvironment !== 'development';
+  let checkEnabled =
+    nodeEnvironment !== 'development' && vercelEnvironment !== 'preview' && vercelEnvironment !== 'development';
   if (process.env.LOGTAIL_CHECK_ENV_VARS?.toLowerCase() === 'true' || process.env.LOGTAIL_CHECK_ENV_VARS === '1') {
     checkEnabled = true;
   }

--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -21,7 +21,9 @@ declare global {
 }
 
 function warnAboutMissingEnvironmentVariables() {
-  let checkEnabled = process.env.NODE_ENV !== 'development';
+  const nodeEnvironment = process.env.NODE_ENV;
+  const vercelEnvironment = process.env.VERCEL_ENV;
+  let checkEnabled = nodeEnvironment !== 'development' && vercelEnvironment !== 'preview' && vercelEnvironment !== 'development';
   if (process.env.LOGTAIL_CHECK_ENV_VARS?.toLowerCase() === 'true' || process.env.LOGTAIL_CHECK_ENV_VARS === '1') {
     checkEnabled = true;
   }


### PR DESCRIPTION
Resolves #6 when building project via `vercel build` by not running the ENV var check when VERCEL_ENV is either `development` or `preview` (similarly to #12).

(Also prevents build warning in example project.)