### PR TITLE
L-1016 By default, don't check ENV vars in Vercel non-production build

### DIFF
--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -21,10 +21,9 @@ declare global {
 }
 
 function warnAboutMissingEnvironmentVariables() {
-  const nodeEnvironment = process.env.NODE_ENV;
-  const vercelEnvironment = process.env.VERCEL_ENV;
-  let checkEnabled =
-    nodeEnvironment !== 'development' && vercelEnvironment !== 'preview' && vercelEnvironment !== 'development';
+  const nodeDevEnv = process.env.NODE_ENV === 'development';
+  const vercelDevEnv = process.env.VERCEL_ENV === 'preview' || process.env.VERCEL_ENV === 'development';
+  let checkEnabled = !nodeDevEnv && !vercelDevEnv;
   if (process.env.LOGTAIL_CHECK_ENV_VARS?.toLowerCase() === 'true' || process.env.LOGTAIL_CHECK_ENV_VARS === '1') {
     checkEnabled = true;
   }

--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -23,7 +23,8 @@ declare global {
 function warnAboutMissingEnvironmentVariables() {
   const nodeDevEnv = process.env.NODE_ENV === 'development';
   const vercelDevEnv = process.env.VERCEL_ENV === 'preview' || process.env.VERCEL_ENV === 'development';
-  let checkEnabled = !nodeDevEnv && !vercelDevEnv;
+  const vercelNonProdBuild = process.env.VERCEL_ENV !== 'production' && process.env.__VERCEL_BUILD_RUNNING === '1';
+  let checkEnabled = !nodeDevEnv && !vercelDevEnv && !vercelNonProdBuild;
   if (process.env.LOGTAIL_CHECK_ENV_VARS?.toLowerCase() === 'true' || process.env.LOGTAIL_CHECK_ENV_VARS === '1') {
     checkEnabled = true;
   }


### PR DESCRIPTION
Resolves https://github.com/logtail/logtail-nextjs/issues/6 when building project via `vercel build` while not having `VERCEL_ENV` variable accessible during build.