### PR TITLE
L-1563 Fix flushing logs in new version of Next.js on Vercel

### DIFF
--- a/src/withLogtail.ts
+++ b/src/withLogtail.ts
@@ -204,13 +204,13 @@ export function withLogtailNextEdgeFunction(handler: NextMiddleware): NextMiddle
       if (res) {
         logger.attachResponseStatus(res.status);
       }
-      ev.waitUntil(logger.flush());
+      await logger.flush();
       logEdgeReport(report);
       return res;
     } catch (error: any) {
       logger.error('Error in edge function', { error });
       logger.attachResponseStatus(500);
-      ev.waitUntil(logger.flush());
+      await logger.flush();
       logEdgeReport(report);
       throw error;
     }


### PR DESCRIPTION
Similar change can be seen in [axiomhq/next-axiom](https://github.com/axiomhq/next-axiom/commit/91db23a684ac57b16e1f4465b8d5317cff368e85#diff-224cf4356ee42b238e21cf441faf006059b2997f195ab56a00bc242cb4a9f742L190-L204).

In my testing, this was the main blocker in having structured logging work out-of-the-box in Vercel, as explained in [our docs](https://betterstack.com/docs/logs/vercel/#optional-structured-logging).

We should also update the docs to ES6 (but that's easily rewritten by devs familiar with JS).