### PR TITLE
Add Next.js 15 as a supported peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@logtail/next",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@logtail/next",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.2"
@@ -25,7 +25,7 @@
         "node": ">=15"
       },
       "peerDependencies": {
-        "next": "^12.1.4 || ^13 || ^14"
+        "next": "^12.1.4 || ^13 || ^14 || ^15"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/logtail/logtail-nextjs#readme",
   "peerDependencies": {
-    "next": "^12.1.4 || ^13 || ^14"
+    "next": "^12.1.4 || ^13 || ^14 || ^15"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",


### PR DESCRIPTION
This PR adds Next.js 15 as a peer dependency to solve #17. Before this PR, using `npm` to install `@logtail/next` gives the following error:

```
npm error Could not resolve dependency:
npm error peer next@"^12.1.4 || ^13 || ^14" from @logtail/next@0.1.5
npm error node_modules/@logtail/next
npm error @logtail/next@"^0.1.5" from the root project

logtail/next seems to be not compatible with NextJS 15
```