### PR TITLE
Send timestamp in "dt" field to be accepted by Better Stack

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -88,7 +88,7 @@ export class Logger {
     }
     const logEvent: LogEvent = { level, message, _time: new Date(Date.now()).toISOString(), fields: this.args || {} };
 
-    // check if passed args is an object, if its not an object, add it to fields.args
+    // check if passed args is an object, if it's not an object, add it to fields.args
     if (args instanceof Error) {
       logEvent.fields = { ...logEvent.fields, message: args.message, stack: args.stack, name: args.name };
     } else if (typeof args === 'object' && args !== null && Object.keys(args).length > 0) {
@@ -139,7 +139,7 @@ export class Logger {
 
     const method = 'POST';
     const keepalive = true;
-    const body = JSON.stringify(this.logEvents);
+    const body = JSON.stringify(this.logEvents.map((event) => ({ dt: event._time, ...event })));
     // clear pending logs
     this.logEvents = [];
     const headers = {

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -13,7 +13,7 @@ export default class GenericConfig implements Provider {
   shouldSendEdgeReport = false;
   token = process.env.LOGTAIL_SOURCE_TOKEN;
   environment: string = process.env.NODE_ENV;
-  logtailUrl = process.env.LOGTAIL_URL || 'https://in.logtail.com';
+  logtailUrl = process.env.LOGTAIL_URL || 'https://in.logs.betterstack.com';
   region = process.env.REGION || undefined;
 
   isEnvVarsSet(): boolean {

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -43,13 +43,15 @@ export default class GenericConfig implements Provider {
   }
 
   wrapWebVitalsObject(metrics: any[]): any {
+    const time = new Date().getTime();
     return metrics.map(m => ({
-        webVital: m,
-        _time: new Date().getTime(),
-        platform: {
-          environment: this.environment,
-          source: 'web-vital',
-        },
+      webVital: m,
+      dt: time,
+      _time: time,
+      platform: {
+        environment: this.environment,
+        source: 'web-vital',
+      },
     }))
   }
 

--- a/src/platform/netlify.ts
+++ b/src/platform/netlify.ts
@@ -19,18 +19,20 @@ export interface NetlifyInfo extends PlatformInfo {
 export default class NetlifyConfig extends GenericConfig implements Provider {
 
   wrapWebVitalsObject(metrics: any[]): any {
+    const time = new Date().getTime();
     return metrics.map(m => ({
       webVital: m,
-        _time: new Date().getTime(),
-        netlify: {
-          environment: this.environment,
-          source: 'web-vital',
-          siteId: netlifySiteId,
-          buildId: netlifyBuildId,
-          context: netlifyContext,
-          deploymentUrl: netlifyDeploymentUrl,
-          deploymentId: netlifyDeploymentId,
-        },
+      dt: time,
+      _time: time,
+      netlify: {
+        environment: this.environment,
+        source: 'web-vital',
+        siteId: netlifySiteId,
+        buildId: netlifyBuildId,
+        context: netlifyContext,
+        deploymentUrl: netlifyDeploymentUrl,
+        deploymentId: netlifyDeploymentId,
+      },
     }))
   }
 

--- a/src/platform/vercel.ts
+++ b/src/platform/vercel.ts
@@ -25,7 +25,9 @@ export default class VercelConfig extends GenericConfig implements Provider {
   // }
 
   wrapWebVitalsObject(metrics: any[]) {
+    const time = new Date().getTime();
     return {
+      dt: time,
       webVitals: metrics,
       environment: this.environment,
     };


### PR DESCRIPTION
I've noticed that timestamp is being sent in `_time` field while Better Stack expects the data in `dt` field.

The filed is either set to `new Date(Date.now()).toISOString()` or `new Date().getTime()`, both values are accepted as per [documentation](https://betterstack.com/docs/logs/http-rest-api/#sending-timestamps).

The change is fully backward compatible, as the `_time` field remains unchanged.

This should make the logs appear in Better Stack with time of the log creation instead of log ingestion.

---

Also updated the logs endpoint from `in.logtail.com` to `in.logs.betterstack.com`.