### PR TITLE
BetterStackRequest now extends NextRequest for better compatibility

### DIFF
--- a/src/withBetterStack.ts
+++ b/src/withBetterStack.ts
@@ -71,12 +71,6 @@ export function withBetterStackRouteHandler(
   config?: BetterStackRouteHandlerConfig
 ): RouteHandler {
   return async (request: NextRequest, context: any) => {
-    let region = '';
-    if ('geo' in request) {
-      // @ts-ignore NextRequest.ip was removed in Next 15, works with undefined
-      region = request.geo?.region ?? '';
-    }
-
     const pathname = request.nextUrl.pathname;
 
     const requestDetails =
@@ -93,7 +87,6 @@ export function withBetterStackRouteHandler(
       userAgent: request.headers.get('user-agent'),
       scheme: request.url.split('://')[0],
       ip: request.headers.get('x-forwarded-for'),
-      region,
       details: Array.isArray(config?.logRequestDetails)
         ? (Object.fromEntries(
             Object.entries(requestDetails as RequestJSON).filter(([key]) =>

--- a/src/withBetterStack.ts
+++ b/src/withBetterStack.ts
@@ -48,7 +48,7 @@ export function withBetterStackNextConfig(nextConfig: NextConfig): NextConfig {
   };
 }
 
-export type BetterStackRequest = Request & {
+export type BetterStackRequest = NextRequest & {
   log: Logger;
   nextUrl?: { hostname: string; pathname: string; protocol: string };
 };


### PR DESCRIPTION
In https://github.com/logtail/logtail-nextjs/pull/31, the type has been generalized. It would be better to keep extending the more specific `NextRequest` in case one would like to use the values e.g. in typed helper functions.

Also removing dead code, since `request.geo` was [removed in Next.js 15](https://nextjs.org/docs/app/api-reference/functions/next-request#version-history), and this library doesn't support older versions anymore